### PR TITLE
Intel archive builds

### DIFF
--- a/.github/workflows/build-intel-archives.yml
+++ b/.github/workflows/build-intel-archives.yml
@@ -3,7 +3,7 @@ name: "Build macOS 26 Intel optimized archives"
 on:
   workflow_dispatch:
   schedule:
-    # Run every 60 days (1st of every other month)
+    # Run at 03:00 on the 1st of every other month
     - cron: '0 3 1 */2 *'
 
 concurrency:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   MACPORTS_VERSION: "2.12.3"

--- a/.github/workflows/build-intel-archives.yml
+++ b/.github/workflows/build-intel-archives.yml
@@ -2,6 +2,9 @@ name: "Build macOS 26 Intel optimized archives"
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run every 60 days (1st of every other month)
+    - cron: '0 3 1 */2 *'
 
 permissions:
   contents: write

--- a/.github/workflows/build-intel-archives.yml
+++ b/.github/workflows/build-intel-archives.yml
@@ -6,6 +6,10 @@ on:
     # Run every 60 days (1st of every other month)
     - cron: '0 3 1 */2 *'
 
+concurrency:
+  group: intel-archives
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/build-intel-archives.yml
+++ b/.github/workflows/build-intel-archives.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: ${{ matrix.group }}
-    runs-on: macos-26
+    runs-on: macos-26-intel
     timeout-minutes: 350
     strategy:
       fail-fast: false
@@ -43,75 +43,40 @@ jobs:
               newt0
 
     steps:
-      - name: Enable Rosetta 2
-        run: softwareupdate --install-rosetta --agree-to-license 2>/dev/null || true
-
       - name: Checkout ports
         uses: actions/checkout@v6
         with:
           path: ports
           show-progress: false
 
-      - name: Disable Spotlight
-        run: sudo mdutil -a -i off
+      - name: Bootstrap MacPorts
+        env:
+          MP_CI_RELEASE: ${{ env.MACPORTS_VERSION }}
+        run: . ports/.github/workflows/bootstrap.sh
 
-      - name: Move Homebrew out of the way
+      - name: Configure optimized builds
         run: |
-          sudo mkdir -p /opt/local-off /opt/homebrew-off
-          test ! -d /usr/local || sudo find /usr/local -mindepth 1 -maxdepth 1 -type d -print -exec mv {} /opt/local-off/ \;
-          test ! -d /opt/homebrew || sudo find /opt/homebrew -mindepth 1 -maxdepth 1 -type d -print -exec mv {} /opt/homebrew-off/ \;
-          test ! -d /usr/local || sudo find /usr/local -mindepth 1 -maxdepth 1 -type f -print -delete
-          test ! -d /opt/homebrew || sudo find /opt/homebrew -mindepth 1 -maxdepth 1 -type f -print -delete
-          hash -r
-
-      - name: Build and install MacPorts from source (x86_64 via Rosetta)
-        run: |
-          set -ex
-          /usr/bin/curl -fsSL \
-            "https://github.com/macports/macports-base/releases/download/v${MACPORTS_VERSION}/MacPorts-${MACPORTS_VERSION}.tar.bz2" \
-            -o MacPorts.tar.bz2
-          tar xf MacPorts.tar.bz2
-          cd "MacPorts-${MACPORTS_VERSION}"
-          arch -x86_64 ./configure --prefix=/opt/local
-          arch -x86_64 make -j$(sysctl -n hw.ncpu)
-          sudo arch -x86_64 make install
-          rm -rf MacPorts.tar.bz2 "MacPorts-${MACPORTS_VERSION}"
-
-      - name: Configure MacPorts
-        run: |
+          source /opt/local/share/macports/setupenv.bash
           echo "/opt/local/bin" >> $GITHUB_PATH
           echo "/opt/local/sbin" >> $GITHUB_PATH
 
-          # Use the local ports tree
-          echo "file://${PWD}/ports [default,nosync]" \
-            | sudo tee /opt/local/etc/macports/sources.conf >/dev/null
-
-          # Optimization and build configuration
+          # Force build from source with Coffee Lake optimization
           cat <<EOF | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
-          ui_interactive no
           buildfromsource always
           configureccflags ${OPT_CFLAGS}
           configurecxxflags ${OPT_CFLAGS}
-          host_blacklist *.distfiles.macports.org *.packages.macports.org
-          preferred_hosts mirror.fcix.net github.com *.github.com
           EOF
-
-          # Create macports user
-          sudo /opt/local/libexec/macports/postflight/postflight
-
-          # Index the ports tree
-          cd ports && /opt/local/bin/portindex
 
       - name: Build ports
         run: |
-          set -eu
+          set -u
           fail=0
           for port in ${{ matrix.ports }}; do
             echo "::group::Building ${port}"
             if sudo /opt/local/bin/port -v install "${port}"; then
               echo "::notice::Successfully built ${port}"
             else
-              echo "::error::Failed to build ${port}"
+              echo "::warning::Failed to build ${port}"
               fail=1
             fi
             echo "::endgroup::"
@@ -174,7 +139,7 @@ jobs:
           name: "macOS 26 Intel -O3 Coffee Lake #${{ github.run_number }}"
           body: |
             Optimized MacPorts archives for Intel **i9-9880H** (Coffee Lake).
-            Built with `-O3 -march=coffeelake -mtune=coffeelake` on macOS 26 x86_64 (Rosetta 2).
+            Built with `-O3 -march=coffeelake -mtune=coffeelake` on macOS 26 Intel.
 
             ## Quick install
 

--- a/.github/workflows/build-intel-archives.yml
+++ b/.github/workflows/build-intel-archives.yml
@@ -1,0 +1,194 @@
+name: "Build macOS 26 Intel optimized archives"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  MACPORTS_VERSION: "2.12.3"
+  # i9-9880H Coffee Lake optimization flags
+  OPT_CFLAGS: "-O3 -march=coffeelake -mtune=coffeelake"
+
+jobs:
+  build:
+    name: ${{ matrix.group }}
+    runs-on: macos-26
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # geneweb pulls in ocaml + most ocaml-* deps.
+          # We also build the pguyot ocaml ports NOT required by geneweb.
+          - group: geneweb
+            ports: >-
+              geneweb
+              ocaml-pcre2
+              ocaml-bos
+              ocaml-camlp5-buildscripts
+          # atomvm needs erlang + elixir + gperf + mbedtls3
+          - group: atomvm
+            ports: atomvm
+          # eqwalizer needs erlang + sbt + graalvm; elp needs eqwalizer
+          - group: eqwalizer-elp
+            ports: >-
+              eqwalizer
+              elp
+          # Quick builds with minimal deps
+          - group: standalone
+            ports: >-
+              stm32flash
+              newt0
+
+    steps:
+      - name: Enable Rosetta 2
+        run: softwareupdate --install-rosetta --agree-to-license 2>/dev/null || true
+
+      - name: Checkout ports
+        uses: actions/checkout@v6
+        with:
+          path: ports
+          show-progress: false
+
+      - name: Disable Spotlight
+        run: sudo mdutil -a -i off
+
+      - name: Move Homebrew out of the way
+        run: |
+          sudo mkdir -p /opt/local-off /opt/homebrew-off
+          test ! -d /usr/local || sudo find /usr/local -mindepth 1 -maxdepth 1 -type d -print -exec mv {} /opt/local-off/ \;
+          test ! -d /opt/homebrew || sudo find /opt/homebrew -mindepth 1 -maxdepth 1 -type d -print -exec mv {} /opt/homebrew-off/ \;
+          test ! -d /usr/local || sudo find /usr/local -mindepth 1 -maxdepth 1 -type f -print -delete
+          test ! -d /opt/homebrew || sudo find /opt/homebrew -mindepth 1 -maxdepth 1 -type f -print -delete
+          hash -r
+
+      - name: Build and install MacPorts from source (x86_64 via Rosetta)
+        run: |
+          set -ex
+          /usr/bin/curl -fsSL \
+            "https://github.com/macports/macports-base/releases/download/v${MACPORTS_VERSION}/MacPorts-${MACPORTS_VERSION}.tar.bz2" \
+            -o MacPorts.tar.bz2
+          tar xf MacPorts.tar.bz2
+          cd "MacPorts-${MACPORTS_VERSION}"
+          arch -x86_64 ./configure --prefix=/opt/local
+          arch -x86_64 make -j$(sysctl -n hw.ncpu)
+          sudo arch -x86_64 make install
+          rm -rf MacPorts.tar.bz2 "MacPorts-${MACPORTS_VERSION}"
+
+      - name: Configure MacPorts
+        run: |
+          echo "/opt/local/bin" >> $GITHUB_PATH
+          echo "/opt/local/sbin" >> $GITHUB_PATH
+
+          # Use the local ports tree
+          echo "file://${PWD}/ports [default,nosync]" \
+            | sudo tee /opt/local/etc/macports/sources.conf >/dev/null
+
+          # Optimization and build configuration
+          cat <<EOF | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
+          ui_interactive no
+          buildfromsource always
+          configureccflags ${OPT_CFLAGS}
+          configurecxxflags ${OPT_CFLAGS}
+          host_blacklist *.distfiles.macports.org *.packages.macports.org
+          preferred_hosts mirror.fcix.net github.com *.github.com
+          EOF
+
+          # Create macports user
+          sudo /opt/local/libexec/macports/postflight/postflight
+
+          # Index the ports tree
+          cd ports && /opt/local/bin/portindex
+
+      - name: Build ports
+        run: |
+          set -eu
+          fail=0
+          for port in ${{ matrix.ports }}; do
+            echo "::group::Building ${port}"
+            if sudo /opt/local/bin/port -v install "${port}"; then
+              echo "::notice::Successfully built ${port}"
+            else
+              echo "::error::Failed to build ${port}"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$fail"
+
+      - name: Collect archives
+        if: always()
+        run: |
+          mkdir -p archives
+          find /opt/local/var/macports/software -name "*.tbz2" -exec cp {} archives/ \;
+
+          echo "### Archives (${{ matrix.group }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          ls -1 archives/ 2>/dev/null | while read f; do
+            size=$(du -h "archives/$f" | cut -f1)
+            echo "- \`${f}\` (${size})" >> $GITHUB_STEP_SUMMARY
+          done
+
+      - name: Upload archives
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: archives-${{ matrix.group }}
+          path: archives/
+          retention-days: 90
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: write
+    steps:
+      - name: Download all archives
+        uses: actions/download-artifact@v6
+        with:
+          path: all-archives
+          pattern: archives-*
+          merge-multiple: true
+
+      - name: Deduplicate archives
+        run: |
+          mkdir -p release
+          # Some archives may be built by multiple jobs (shared deps);
+          # keep one copy of each.
+          for f in all-archives/*.tbz2; do
+            [ -f "$f" ] || continue
+            bn=$(basename "$f")
+            cp -n "$f" "release/$bn" 2>/dev/null || true
+          done
+          echo "Total unique archives: $(ls release/*.tbz2 2>/dev/null | wc -l)"
+          ls -lhS release/
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: intel-o3-coffeelake-${{ github.run_number }}
+          name: "macOS 26 Intel -O3 Coffee Lake #${{ github.run_number }}"
+          body: |
+            Optimized MacPorts archives for Intel **i9-9880H** (Coffee Lake).
+            Built with `-O3 -march=coffeelake -mtune=coffeelake` on macOS 26 x86_64 (Rosetta 2).
+
+            ## Quick install
+
+            ```bash
+            # Download all archives to a temporary directory
+            gh release download intel-o3-coffeelake-${{ github.run_number }} \
+              --repo ${{ github.repository }} -p '*.tbz2' -D /tmp/mp-archives
+
+            # Install a single port from its archive
+            sudo port install /tmp/mp-archives/<portname>-<version>.darwin_26.x86_64.tbz2
+
+            # Or: configure MacPorts to use these as a local archive source
+            echo "archive_site_local file:///tmp/mp-archives/:tbz2" \
+              | sudo tee -a /opt/local/etc/macports/macports.conf
+            # Then just: sudo port install <portname>
+            ```
+          files: release/*.tbz2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to build and publish macOS Intel-optimized archives. It produces downloadable installer archives for multiple port groups, provides a release with installation instructions, and retains artifacts for 90 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->